### PR TITLE
components/__init__.py: Expose component functions for direct import

### DIFF
--- a/src/mesa_interactive/components/__init__.py
+++ b/src/mesa_interactive/components/__init__.py
@@ -1,0 +1,3 @@
+from .charts import create_chart
+from .grid import create_grid
+from .markdown import create_markdown


### PR DESCRIPTION
### Description:

This PR updates the `components/__init__.py` to expose main component functions (`create_chart`, `create_grid`, `create_markdown`) for direct imports. This provides a more user-friendly import experience and aligns with the README's example usage.

#### Changes:

- Updated `components/__init__.py` to import `create_chart`, `create_grid`, and `create_markdown` for direct accessibility.
  
#### Motivation:

Users can now perform the following import:
```python
from mesa_interactive.components import create_chart, create_grid, create_markdown
```
instead of diving into sub-modules, like this:
```Python
from mesa_interactive.components.charts import create_chart
from mesa_interactive.components.grid import create_grid
from mesa_interactive.components.markdown import  create_markdown
```

Closes #1.