### PR TITLE
CI: Create workflow that builds and deploys wheels to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  release:
+    name: Deploy release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -U pip build wheel setuptools
+      - name: Build distributions
+        run: python -m build
+      - name: Upload package as artifact to GitHub
+        if: github.repository == 'projectmesa/mesa' && startsWith(github.ref, 'refs/tags')
+        uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: dist/
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Upload package as artifact to GitHub
-        if: github.repository == 'projectmesa/mesa' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'corvince/mesa-interactive' && startsWith(github.ref, 'refs/tags')
         uses: actions/upload-artifact@v3
         with:
           name: package


### PR DESCRIPTION
Add a CI workflow that automatically builds mesa-interactive and deploys a wheel to PyPI. If runs on each push and pull request to test wheel building, but only deploys to PyPI when a tag is created.

To deploy to PyPI is uses the [PyPI publish GitHub Action](https://github.com/pypa/gh-action-pypi-publish). It uses the [API token](https://pypi.org/help/#apitoken) feature of PyPI, which is recommended to restrict the access the action has.

The secret used in `${{ secrets.PYPI_API_TOKEN }}` needs to be created on the settings page. See [Creating & using secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).

After uploading the API token, any maintainer can just create a new tag, after which this action will upload the wheel and dist to PyPI.