### PR TITLE
Fix coord iter for single agents

### DIFF
--- a/src/mesa_interactive/components/grid.py
+++ b/src/mesa_interactive/components/grid.py
@@ -9,6 +9,8 @@ import solara
 def get_agent_data_from_coord_iter(agents_per_coordinate):
     for agents, (x, y) in agents_per_coordinate:
         if agents:  # Checking if the list is non-empty
+            if agents not isinstance(list):
+                agents = [agents]
             for agent in agents:
                 agent_data = json.loads(
                     json.dumps(agent.__dict__, skipkeys=True, default=str)

--- a/src/mesa_interactive/components/grid.py
+++ b/src/mesa_interactive/components/grid.py
@@ -9,7 +9,7 @@ import solara
 def get_agent_data_from_coord_iter(agents_per_coordinate):
     for agents, (x, y) in agents_per_coordinate:
         if agents:  # Checking if the list is non-empty
-            if agents not isinstance(list):
+            if not isinstance(agents, list):
                 agents = [agents]
             for agent in agents:
                 agent_data = json.loads(


### PR DESCRIPTION
Fixes the issue in #13. Apparently, in Mesa's `grid.coord_iter` sometime a single agent is returned, instead of a list (with a single agent).